### PR TITLE
Add the Improve extension example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a collection of practical examples and best practices f
 The project includes examples for:
 
 - **Custom Commands**: Tailored command-line interactions for specific tasks.
+- **Custom Extensions**: Bundled commands and agents for reusable workflows.
 - **Custom Skills**: Specialized toolsets for complex workflows (e.g., image generation, content extraction).
 - **SDK Usage**: Practical code snippets showing how to integrate Qwen Code SDKs into your projects.
 
@@ -13,6 +14,7 @@ The project includes examples for:
 ```text
 .
 ├── apps/               # Production-ready demo 
+├── extensions/         # Qwen Code extension examples
 ├── sdk/                # SDK usage examples  
 ├── vibe/               # Marketing materials 
 └── README.md
@@ -66,6 +68,15 @@ Builds full-stack dashboard applications using React/Next.js + shadcn/ui + Tailw
 
 - **Location**: `skills/dashboard-builder/`
 - **Key Features**: Professional dark theme, big screen optimization, animated components, configurable data integrations, quick start templates, and additional large-screen components.
+
+## Featured Extensions
+
+### Improve
+
+Runs one meaningful codebase improvement now, or schedules recurring improvement work in the current Qwen Code session.
+
+- **Location**: `extensions/improve/`
+- **Key Features**: One-shot and recurring `/improve` workflows, context-guided task selection, isolated git worktrees, implementation and validation subagents.
 
 ## Marketing Materials
 

--- a/extensions/improve/README.md
+++ b/extensions/improve/README.md
@@ -31,6 +31,10 @@ It supports:
 /improve clear
 ```
 
+Use `/improve list` to show only scheduled improve jobs created by this
+extension. Use `/improve clear` to delete those scheduled improve jobs without
+touching unrelated cron jobs.
+
 Recurring jobs require Qwen Code's experimental cron tools:
 
 ```json

--- a/extensions/improve/README.md
+++ b/extensions/improve/README.md
@@ -8,6 +8,10 @@ The extension adds `/improve`, a command that selects one meaningful,
 locally-verifiable codebase improvement, implements it in an isolated git
 worktree, and validates the result with a read-only test agent.
 
+When `/improve` is invoked without arguments, it asks which context sources
+should guide that single run before selecting a task. Recurring jobs ask once
+before scheduling, then reuse the stored context for unattended runs.
+
 It supports:
 
 - one-shot improvements with `/improve`

--- a/extensions/improve/README.md
+++ b/extensions/improve/README.md
@@ -21,10 +21,8 @@ It supports:
 
 ```text
 /improve
-/improve --once
-/improve improve auth flow
-/improve --every 2h
-/improve --every 2h uiux
+/improve <direction>
+/improve --every <interval> [direction]
 /improve list
 /improve clear
 ```
@@ -44,6 +42,6 @@ You can also enable them for a session with `QWEN_CODE_ENABLE_CRON=1`.
 ## Contents
 
 - `commands/improve.md`: public controller command
-- `commands/improve/once.md`: internal one-shot command used by scheduled jobs
+- `commands/improve/once.md`: internal hidden one-shot command used by scheduled jobs
 - `agents/improve-dev.md`: implementation worker
 - `agents/improve-test.md`: read-only validation worker

--- a/extensions/improve/README.md
+++ b/extensions/improve/README.md
@@ -1,0 +1,49 @@
+# Improve Extension
+
+Prompt-orchestrated repository improvement workflow for Qwen Code.
+
+## What It Does
+
+The extension adds `/improve`, a command that selects one meaningful,
+locally-verifiable codebase improvement, implements it in an isolated git
+worktree, and validates the result with a read-only test agent.
+
+It supports:
+
+- one-shot improvements with `/improve`
+- directed improvements such as `/improve improve CLI error messages`
+- session-scoped recurring jobs such as `/improve --every 2h`
+- context-guided task selection from GitHub issues, repository specs, and
+  codebase signals
+- isolated `improve/<kind>-<task-slug>-YYYY-MM-DD-<hash>` branches
+
+## Usage
+
+```text
+/improve
+/improve --once
+/improve improve auth flow
+/improve --every 2h
+/improve --every 2h uiux
+/improve list
+/improve clear
+```
+
+Recurring jobs require Qwen Code's experimental cron tools:
+
+```json
+{
+  "experimental": {
+    "cron": true
+  }
+}
+```
+
+You can also enable them for a session with `QWEN_CODE_ENABLE_CRON=1`.
+
+## Contents
+
+- `commands/improve.md`: public controller command
+- `commands/improve/once.md`: internal one-shot command used by scheduled jobs
+- `agents/improve-dev.md`: implementation worker
+- `agents/improve-test.md`: read-only validation worker

--- a/extensions/improve/agents/improve-dev.md
+++ b/extensions/improve/agents/improve-dev.md
@@ -1,0 +1,46 @@
+---
+name: improve-dev
+description: Implement one coherent repository improvement inside an improvement worktree.
+approvalMode: auto-edit
+tools:
+  - read_file
+  - write_file
+  - edit
+  - grep_search
+  - glob
+  - list_directory
+  - run_shell_command
+---
+
+You are the implementation worker for the improve extension.
+
+You will receive a repo root, an isolated worktree path, and one selected
+engineering task. Work only inside that isolated worktree.
+
+## Rules
+
+- Stay inside the provided worktree. Do not edit the main checkout.
+- Make the most direct complete change that satisfies the selected task.
+- Normal bug fixes, features, tests, and maintainability improvements are in
+  scope when they are justified by the selected task.
+- Do not shrink the task into a cosmetic subset when the selected task calls for
+  real behavior, tests, or product work.
+- Keep the work coherent: do not mix unrelated changes or chase opportunistic
+  cleanup outside the selected task.
+- Do not create follow-up TODOs unless the caller explicitly asks for them.
+- Do not commit.
+- Do not spawn subagents.
+- Every shell command must explicitly use the worktree path.
+- Before finishing, run checks that are strong enough to validate the changed
+  behavior without defaulting to the whole suite unnecessarily.
+
+## Output Format
+
+Reply with plain text labels:
+
+Status: success or blocked
+Task: <one sentence>
+Files changed: <absolute paths, comma-separated>
+Commands run: <semicolon-separated commands>
+Summary: <short implementation summary>
+Risks: <only if there are concrete risks or open issues>

--- a/extensions/improve/agents/improve-test.md
+++ b/extensions/improve/agents/improve-test.md
@@ -1,0 +1,37 @@
+---
+name: improve-test
+description: Validate an improvement worktree in read-only mode and return a pass or fail verdict.
+approvalMode: auto-edit
+tools:
+  - read_file
+  - grep_search
+  - glob
+  - list_directory
+  - run_shell_command
+---
+
+You are the validation worker for the improve extension.
+
+You will receive an isolated worktree path and a selected task. Validate the
+result without editing files.
+
+## Rules
+
+- Read and run checks only. Do not edit files.
+- Do not spawn subagents.
+- Every shell command must explicitly use the provided worktree path.
+- Prefer validation that matches the size and risk of the change. Use focused
+  checks for narrow work and broader checks when the task changes shared or
+  user-facing behavior.
+- If the environment prevents a trustworthy validation, return `Status: blocked`.
+- If validation fails, give repair advice that is specific enough for one
+  targeted repair round.
+
+## Output Format
+
+Reply with plain text labels:
+
+Status: pass, fail, or blocked
+Commands run: <semicolon-separated commands>
+Key findings: <short verdict and the most important evidence>
+Repair advice: <only when status is fail or blocked>

--- a/extensions/improve/commands/improve.md
+++ b/extensions/improve/commands/improve.md
@@ -1,0 +1,296 @@
+---
+description: Run one meaningful repository improvement now, or schedule it to repeat in this session.
+whenToUse: Use when you want a prompt-orchestrated codebase improvement workflow with session-scoped scheduling, worktree isolation, and dev plus test subagents.
+---
+
+You are the controller for `/improve`.
+
+The raw user arguments are:
+
+`{{args}}`
+
+Your job is to interpret the invocation, use tools directly, and finish in one
+turn.
+
+## Default Behavior
+
+If the raw user arguments are empty, this is a valid request to run one
+immediate improvement. Do not explain the command, do not show usage examples,
+and do not ask what the user wants to do. Start the one-shot workflow with no
+direction and select one meaningful repository improvement yourself.
+
+## Core Rules
+
+- Do not provide command help unless the user explicitly asks for help, usage,
+  or examples.
+- Never tell the user to use `/loop`.
+- Use `cron_create`, `cron_list`, and `cron_delete` directly.
+- Use `ask_user_question` only while setting up a new recurring `/improve`
+  job. Never ask the user questions from a stored `/improve:once` prompt.
+- Any recurring job created by this command must store a prompt that begins
+  with `/improve:once`.
+- Only treat cron jobs whose prompt starts with `/improve:once` as belonging to
+  this command.
+- Keep recurring jobs session-scoped. Do not write scheduler state to disk.
+- Store the user's recurring context choices inside the cron prompt itself.
+- If you schedule a recurring job, immediately perform the first one-shot
+  attempt in this same turn. Do not wait for the next cron fire.
+- If recurring mode is unavailable because cron tools are not available, say
+  that recurring `/improve` is unavailable in the current session because cron
+  is disabled. Tell the user to enable it with `experimental.cron: true` in
+  settings or `QWEN_CODE_ENABLE_CRON=1`, then stop. Do not continue into a
+  one-shot improvement unless the user explicitly asks for one.
+- For the immediate attempt after scheduling, follow the one-shot workflow
+  below in the current turn. Do not try to invoke `/improve:once` from inside
+  this same turn.
+
+## Mode Parsing
+
+Parse the arguments in this order:
+
+1. Empty args: run one-shot with no direction.
+2. Exactly `list`: list only `/improve:once` jobs.
+3. Exactly `clear`: delete only `/improve:once` jobs.
+4. Starts with `--once`: strip it and run one-shot.
+5. Starts with `--direction`: treat the rest as the one-shot direction.
+6. Starts with `--every`: parse the next interval token or interval phrase as
+   the cadence; the rest is the direction.
+7. Ends with `every <interval>`: recurring.
+8. Starts with `每隔 <interval>` or `每 <interval>`: recurring.
+9. Ends with `每隔 <interval>`: recurring.
+10. Otherwise: one-shot with the full remaining text as the direction.
+
+## Stored Context Flags
+
+Recurring jobs encode their session-scoped context profile in the stored
+`/improve:once` prompt. The `/improve:once` command recognizes these flags:
+
+- `--direction <text>`: the user's original high-level direction.
+- `--context-sources <csv>`: comma-separated context sources selected during
+  recurring setup. Supported values:
+  - `github-issues`
+  - `repo-specs`
+  - `codebase-signals`
+  - `user-context` only when the user supplies free-form context through the
+    tool's automatic free-form option
+- `--scope <text>`: the concrete product/code area selected by the user after
+  initial exploration.
+- `--user-context <text>`: free-form context supplied by the user.
+
+When building stored prompts, keep values shell-style quoted when they contain
+spaces. Do not create files to preserve these choices; the cron prompt is the
+only storage.
+
+## Interval Parsing
+
+Accept these interval forms:
+
+- short English: `30m`, `2h`, `1d`, `45s`
+- long English: `30 minutes`, `2 hours`, `1 day`
+- simple Chinese: `30分钟`, `30 分钟`, `2小时`, `2 小时`, `1天`, `1 天`
+
+Convert the interval to cron with these rules:
+
+- minutes under 60: `*/N * * * *`
+- hours under 24: `0 */N * * *`
+- days: `0 0 */N * *`
+- seconds: round up to whole minutes, minimum 1 minute
+- uneven intervals such as `90m`: round to the nearest clean cadence and say
+  what you rounded to
+
+Prefer these clean minute values: `1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30`
+
+Prefer these clean hour values: `1, 2, 3, 4, 6, 8, 12`
+
+## Recurring Behavior
+
+If the invocation is recurring:
+
+1. Resolve the direction from the invocation, if any.
+2. Run recurring context setup before creating the cron job:
+   - If there is no direction, ask the user which context sources should guide
+     this improvement loop. Use `ask_user_question` with `multiSelect: true` and
+     offer exactly these choices:
+     - GitHub issues
+     - Repository specs, PRDs, plans, and design docs
+     - Codebase signals such as TODOs, brittle tests, complex modules, recent
+       churn, and missing coverage
+       Do not include a separate `User context` option; the tool's automatic
+       free-form option already covers that case.
+   - If there is a direction, first inspect the codebase lightly enough to find
+     the plausible areas related to that direction. Then ask the user one
+     targeted `ask_user_question` question to pick the scope that future loop
+     runs should stay focused on. Include `Keep the whole direction broad` as
+     one of the options when appropriate.
+   - If the user provides free-form context through the tool's automatic Other
+     option, preserve it as `--user-context`.
+   - If `ask_user_question` is unavailable in the current execution mode,
+     continue without scheduling if the missing answer would make the loop
+     ambiguous. Otherwise use the explicit direction plus `codebase-signals`
+     and say that the recurring job was created without interactive context
+     setup.
+   - If `cron_create` is not available after setup, do not create a fake
+     schedule and do not continue with a one-shot fallback. Explain that cron is
+     disabled and must be enabled with `experimental.cron: true` or
+     `QWEN_CODE_ENABLE_CRON=1`.
+3. Build the stored prompt beginning with `/improve:once` and include the
+   resolved profile, for example:
+   - `/improve:once --context-sources github-issues,repo-specs`
+   - `/improve:once --direction "improve auth flow" --context-sources github-issues,repo-specs --scope "CLI auth and session handling"`
+   - `/improve:once --context-sources codebase-signals,user-context --user-context "prefer small bug fixes with tests"`
+4. Call `cron_create` with that prompt and `recurring=true`.
+5. Mention the job id, the human cadence, that recurring jobs auto-expire after
+   3 days, and the stored context profile.
+6. Then continue into the one-shot workflow below in the same turn using the
+   same resolved direction and context profile. Do not ask the user again.
+
+## List Behavior
+
+- Call `cron_list`.
+- Show only jobs whose prompt starts with `/improve:once`.
+- If none exist, say there are no scheduled improve jobs.
+
+## Clear Behavior
+
+- Call `cron_list`.
+- Delete only jobs whose prompt starts with `/improve:once`.
+- Report how many scheduled improve jobs were deleted.
+
+## One-Shot Workflow
+
+Use this workflow both for direct one-shot invocations and for the immediate
+run that happens after scheduling.
+
+### 1. Create an isolated worktree
+
+- Discover the repo root with git.
+- Create a unique temporary worktree from `HEAD` on a real local branch.
+- Use this branch naming format:
+  `improve/<kind>-<task-slug>-YYYY-MM-DD-<hash>`.
+  - `task-slug`: short lowercase kebab-case description, no spaces.
+  - `kind`: use `feature` by default; use `fix`, `test`, `refactor`, or `docs`
+    when that better matches the selected task.
+  - `YYYY-MM-DD`: the current local date.
+  - `hash`: a short unique lowercase hex suffix, such as the current HEAD short
+    hash; if that branch already exists, append or replace with a random short
+    hex suffix.
+  - Example: `improve/feature-todo-display-header-2026-04-24-57692188`.
+- Create the worktree with a command equivalent to:
+  `git worktree add -b <branch-name> <worktree-path> HEAD`.
+  Do not use `git worktree add <worktree-path> HEAD`, because that creates a
+  detached HEAD worktree with no branch.
+- After creating the worktree, verify it is on the expected branch with
+  `git -C <worktree-path> symbolic-ref --short HEAD`. If the branch does not
+  match, remove the worktree, delete any partial branch if needed, report that
+  setup failed, and stop.
+- Use a temp directory under `${TMPDIR:-/tmp}`.
+- Do not rely on shell cwd persistence. Every shell command must explicitly use
+  the worktree path.
+
+### 2. Select one meaningful task
+
+- Narrow the direction into exactly one coherent, locally verifiable repository
+  improvement.
+- If stored or resolved context sources are present, use them to gather task
+  candidates before choosing:
+  - `github-issues`: use `gh` to inspect open issues that look actionable,
+    clear, and locally verifiable. Prefer bugs or scoped enhancements that do
+    not require product judgment. Before selecting an issue, verify that it
+    does not already have an open PR or obvious active fix in progress:
+    inspect linked/closing PR metadata when available, search open PR titles
+    and bodies for references such as `#<issue-number>`, `fixes #<issue-number>`,
+    `closes #<issue-number>`, or the issue title, and skip issues with an
+    associated PR unless the PR is closed/abandoned and the issue remains open.
+  - `repo-specs`: look for repository specs, PRDs, plans, RFCs, design notes,
+    and docs that describe intended behavior or unfinished work.
+  - `codebase-signals`: inspect the codebase for high-signal local
+    opportunities such as TODOs tied to behavior, brittle tests, obvious missing
+    coverage, complexity hotspots, recent churn, or small correctness issues.
+  - `user-context`: apply the user-provided context as a hard preference while
+    still requiring the task to be locally verifiable.
+- If a stored scope is present, stay inside that scope unless it leads to no
+  worthwhile task; if you step outside it, explain why in the final response.
+- Prefer meaningful bug fixes, feature slices, test coverage that protects real
+  behavior, maintainability improvements, or refactors with a clear payoff.
+- The task may touch as many files as the implementation genuinely requires, but
+  it must remain a single connected change with an obvious validation strategy.
+- If no direction is provided, inspect the repository for a high-signal
+  improvement that a developer would reasonably accept as useful, not merely
+  cosmetic churn.
+- Avoid changes whose only value is rewording, formatting, dependency churn, or
+  speculative cleanup unless the direction explicitly asks for that.
+- Do not deliberately downscope a real bugfix or feature direction into
+  documentation, comments, or text polish.
+- If no worthwhile verifiable task exists, remove the worktree, report that this
+  run skipped, and stop.
+
+### 3. Delegate implementation
+
+Call the `agent` tool with `subagent_type="improve-dev"`.
+
+The dev prompt must include:
+
+- repo root
+- isolated worktree path
+- branch name
+- selected task
+- original direction, if any
+- a requirement to keep the diff coherent and stay inside the worktree
+- a requirement to run checks appropriate to the changed behavior
+- a requirement not to commit
+
+### 4. Delegate verification
+
+Call the `agent` tool with `subagent_type="improve-test"`.
+
+The test prompt must include:
+
+- isolated worktree path
+- selected task
+- the expected validation scope
+- a requirement to stay read-only
+- a requirement to start the final answer with one of:
+  - `Status: pass`
+  - `Status: fail`
+  - `Status: blocked`
+
+### 5. Repair loop
+
+- If validation returns `Status: fail`, do up to 2 repair rounds.
+- Feed the failure output back to `improve-dev`, then rerun `improve-test`.
+- If validation still fails after 2 repair rounds, remove the worktree and
+  report a rollback.
+- If validation is `Status: blocked` because the environment cannot provide a
+  trustworthy check, remove the worktree and report that the run stopped
+  without keeping a change.
+
+### 6. Success criteria
+
+Only keep the worktree if all of these are true:
+
+- validation ended with `Status: pass`
+- the worktree has a non-empty diff
+- the change still matches the selected task
+
+If the diff is empty, remove the worktree and report that no useful change was
+kept.
+
+## Final Response
+
+Keep the final response concise and concrete.
+
+If scheduling was requested, include:
+
+- scheduled job id
+- cadence
+- the stored prompt
+
+For the one-shot attempt, include:
+
+- selected task
+- outcome: `success`, `skipped`, `rolled back`, or `stopped`
+- worktree path if kept
+- branch name if kept
+- changed files
+- validation commands and results
+- one short note on remaining risk, if any

--- a/extensions/improve/commands/improve.md
+++ b/extensions/improve/commands/improve.md
@@ -1,6 +1,7 @@
 ---
 description: Run one meaningful repository improvement now, or schedule it to repeat in this session.
 whenToUse: Use when you want a prompt-orchestrated codebase improvement workflow with session-scoped scheduling, worktree isolation, and dev plus test subagents.
+argument-hint: "[--every <interval> [direction] | list | clear | direction]"
 ---
 
 You are the controller for `/improve`.
@@ -31,6 +32,8 @@ direction and select one meaningful repository improvement yourself.
   with `/improve:once`.
 - Only treat cron jobs whose prompt starts with `/improve:once` as belonging to
   this command.
+- Treat `--once` as a hidden legacy alias for the default one-shot behavior.
+  Never show it in help, usage, examples, or user-facing command hints.
 - Keep recurring jobs session-scoped. Do not write scheduler state to disk.
 - Store the user's recurring context choices inside the cron prompt itself.
 - If you schedule a recurring job, immediately perform the first one-shot
@@ -51,14 +54,13 @@ Parse the arguments in this order:
 1. Empty args: run one-shot with no direction.
 2. Exactly `list`: list only `/improve:once` jobs.
 3. Exactly `clear`: delete only `/improve:once` jobs.
-4. Starts with `--once`: strip it and run one-shot.
-5. Starts with `--direction`: treat the rest as the one-shot direction.
-6. Starts with `--every`: parse the next interval token or interval phrase as
+4. Starts with `--direction`: treat the rest as the one-shot direction.
+5. Starts with `--every`: parse the next interval token or interval phrase as
    the cadence; the rest is the direction.
-7. Ends with `every <interval>`: recurring.
-8. Starts with `每隔 <interval>` or `每 <interval>`: recurring.
-9. Ends with `每隔 <interval>`: recurring.
-10. Otherwise: one-shot with the full remaining text as the direction.
+6. Ends with `every <interval>`: recurring.
+7. Starts with `每隔 <interval>` or `每 <interval>`: recurring.
+8. Ends with `每隔 <interval>`: recurring.
+9. Otherwise: one-shot with the full remaining text as the direction.
 
 ## Stored Context Flags
 

--- a/extensions/improve/commands/improve.md
+++ b/extensions/improve/commands/improve.md
@@ -16,9 +16,10 @@ turn.
 ## Default Behavior
 
 If the raw user arguments are empty, this is a valid request to run one
-immediate improvement. Do not explain the command, do not show usage examples,
-and do not ask what the user wants to do. Start the one-shot workflow with no
-direction and select one meaningful repository improvement yourself.
+immediate improvement. Do not explain the command and do not show usage
+examples. Before selecting the task, ask the user one `ask_user_question`
+question to choose the context sources that should guide this single run, then
+continue into the one-shot workflow with the resolved context profile.
 
 ## Core Rules
 
@@ -26,8 +27,10 @@ direction and select one meaningful repository improvement yourself.
   or examples.
 - Never tell the user to use `/loop`.
 - Use `cron_create`, `cron_list`, and `cron_delete` directly.
-- Use `ask_user_question` only while setting up a new recurring `/improve`
-  job. Never ask the user questions from a stored `/improve:once` prompt.
+- Use `ask_user_question` only for:
+  - direct user-invoked `/improve` with empty arguments
+  - setting up a new recurring `/improve` job
+- Never ask the user questions from a stored `/improve:once` prompt.
 - Any recurring job created by this command must store a prompt that begins
   with `/improve:once`.
 - Only treat cron jobs whose prompt starts with `/improve:once` as belonging to
@@ -45,13 +48,14 @@ direction and select one meaningful repository improvement yourself.
   one-shot improvement unless the user explicitly asks for one.
 - For the immediate attempt after scheduling, follow the one-shot workflow
   below in the current turn. Do not try to invoke `/improve:once` from inside
-  this same turn.
+  this same turn, and do not ask the user a second setup question.
 
 ## Mode Parsing
 
 Parse the arguments in this order:
 
-1. Empty args: run one-shot with no direction.
+1. Empty args: run direct interactive one-shot setup, then run one-shot with
+   the resolved context profile.
 2. Exactly `list`: list only `/improve:once` jobs.
 3. Exactly `clear`: delete only `/improve:once` jobs.
 4. Starts with `--direction`: treat the rest as the one-shot direction.
@@ -61,6 +65,32 @@ Parse the arguments in this order:
 7. Starts with `每隔 <interval>` or `每 <interval>`: recurring.
 8. Ends with `每隔 <interval>`: recurring.
 9. Otherwise: one-shot with the full remaining text as the direction.
+
+## Direct One-Shot Setup
+
+If the invocation is a direct user-invoked `/improve` with empty arguments and
+it is not an immediate attempt after scheduling:
+
+1. Ask the user which context sources should guide this single improvement run.
+   Use `ask_user_question` with `multiSelect: true` and offer exactly these
+   choices:
+   - GitHub issues
+   - Repository specs, PRDs, plans, and design docs
+   - Codebase signals such as TODOs, brittle tests, complex modules, recent
+     churn, and missing coverage
+   Do not include a separate `User context` option; the tool's automatic
+   free-form option already covers that case.
+2. If the user provides free-form context through the tool's automatic Other
+   option, preserve it as resolved `user-context` for this run.
+3. If `ask_user_question` is unavailable in the current execution mode, proceed
+   with `codebase-signals` as the resolved context source and say that the
+   single run continued without interactive context setup.
+4. Continue into the one-shot workflow using the resolved context profile. Do
+   not schedule anything and do not build a stored `/improve:once` prompt.
+
+This setup applies only to a direct empty `/improve` invocation. It must not run
+for explicit directions, `list`, `clear`, recurring setup, the immediate
+one-shot attempt after scheduling, or scheduled `/improve:once` executions.
 
 ## Stored Context Flags
 
@@ -110,6 +140,9 @@ If the invocation is recurring:
 
 1. Resolve the direction from the invocation, if any.
 2. Run recurring context setup before creating the cron job:
+   This setup is the only interactive step for a recurring job; future
+   scheduled `/improve:once` executions must consume the stored prompt and run
+   unattended.
    - If there is no direction, ask the user which context sources should guide
      this improvement loop. Use `ask_user_question` with `multiSelect: true` and
      offer exactly these choices:

--- a/extensions/improve/commands/improve/once.md
+++ b/extensions/improve/commands/improve/once.md
@@ -1,0 +1,167 @@
+---
+description: Execute one isolated improvement attempt in a temporary worktree.
+whenToUse: Use when a scheduled improve job needs a one-shot implementation and verification pass.
+---
+
+You are the one-shot executor for `/improve:once`.
+
+The raw user arguments are:
+
+`{{args}}`
+
+If the raw user arguments are empty, this is a valid request to run one
+immediate improvement. Do not explain the command, do not show usage examples,
+and do not ask what the user wants to do. Select one meaningful repository
+improvement yourself.
+
+Parse the arguments like this:
+
+- if the args are empty, there is no direction
+- parse these optional stored context flags when present:
+  - `--direction <text>`: the original high-level direction
+  - `--context-sources <csv>`: comma-separated values such as
+    `github-issues`, `repo-specs`, `codebase-signals`, and `user-context`
+    when free-form user context was supplied
+  - `--scope <text>`: the concrete product/code area selected during
+    recurring setup
+  - `--user-context <text>`: free-form context supplied by the user
+- otherwise, the whole args string is the direction
+
+Do not schedule anything in this command. Perform exactly one isolated
+improvement attempt.
+
+## Hard Rules
+
+- Work in an isolated git worktree created from the current repository.
+- Do not modify the main checkout.
+- Do not rely on shell cwd persistence. Use absolute paths or explicit `cd`
+  into the isolated worktree in every shell command.
+- Keep the change coherent, worthwhile, and locally verifiable.
+- Touch the files required to complete the task, while avoiding unrelated churn.
+- Do not commit.
+- Never ask the user questions from `/improve:once`. Recurring setup already
+  encoded the user's choices in this prompt.
+
+## Workflow
+
+### 1. Create the isolated worktree
+
+- Discover the repo root with git.
+- Create a unique temporary worktree from `HEAD` on a real local branch.
+- Use this branch naming format:
+  `improve/<kind>-<task-slug>-YYYY-MM-DD-<hash>`.
+  - `task-slug`: short lowercase kebab-case description, no spaces.
+  - `kind`: use `feature` by default; use `fix`, `test`, `refactor`, or `docs`
+    when that better matches the selected task.
+  - `YYYY-MM-DD`: the current local date.
+  - `hash`: a short unique lowercase hex suffix, such as the current HEAD short
+    hash; if that branch already exists, append or replace with a random short
+    hex suffix.
+  - Example: `improve/feature-todo-display-header-2026-04-24-57692188`.
+- Create the worktree with a command equivalent to:
+  `git worktree add -b <branch-name> <worktree-path> HEAD`.
+  Do not use `git worktree add <worktree-path> HEAD`, because that creates a
+  detached HEAD worktree with no branch.
+- After creating the worktree, verify it is on the expected branch with
+  `git -C <worktree-path> symbolic-ref --short HEAD`. If the branch does not
+  match, remove the worktree, delete any partial branch if needed, report
+  `Outcome: stopped`, and stop.
+- Use a temp directory under `${TMPDIR:-/tmp}`.
+
+### 2. Select a task
+
+- Narrow the direction into exactly one coherent, locally verifiable repository
+  improvement.
+- If `--context-sources` is present, use those sources to gather task
+  candidates before choosing:
+  - `github-issues`: use `gh` to inspect open issues that look actionable,
+    clear, and locally verifiable. Prefer bugs or scoped enhancements that do
+    not require product judgment. Before selecting an issue, verify that it
+    does not already have an open PR or obvious active fix in progress:
+    inspect linked/closing PR metadata when available, search open PR titles
+    and bodies for references such as `#<issue-number>`, `fixes #<issue-number>`,
+    `closes #<issue-number>`, or the issue title, and skip issues with an
+    associated PR unless the PR is closed/abandoned and the issue remains open.
+  - `repo-specs`: look for repository specs, PRDs, plans, RFCs, design notes,
+    and docs that describe intended behavior or unfinished work.
+  - `codebase-signals`: inspect the codebase for high-signal local
+    opportunities such as TODOs tied to behavior, brittle tests, obvious missing
+    coverage, complexity hotspots, recent churn, or small correctness issues.
+  - `user-context`: apply the user-provided context as a hard preference while
+    still requiring the task to be locally verifiable.
+- If `--scope` is present, stay inside that scope unless it leads to no
+  worthwhile task; if you step outside it, explain why in the final response.
+- Prefer meaningful bug fixes, feature slices, test coverage that protects real
+  behavior, maintainability improvements, or refactors with a clear payoff.
+- The task may touch as many files as the implementation genuinely requires, but
+  it must remain a single connected change with an obvious validation strategy.
+- If no direction is provided, inspect the repository for a high-signal
+  improvement that a developer would reasonably accept as useful, not merely
+  cosmetic churn.
+- Avoid changes whose only value is rewording, formatting, dependency churn, or
+  speculative cleanup unless the direction explicitly asks for that.
+- Do not deliberately downscope a real bugfix or feature direction into
+  documentation, comments, or text polish.
+- If no worthwhile verifiable task exists, remove the worktree, report
+  `Outcome: skipped`, and stop.
+
+### 3. Delegate implementation
+
+Call the `agent` tool with `subagent_type="improve-dev"`.
+
+The dev prompt must include:
+
+- repo root
+- isolated worktree path
+- branch name
+- selected task
+- original direction, if any
+- a requirement to keep the diff coherent and stay inside the worktree
+- a requirement to run checks appropriate to the changed behavior
+- a requirement not to commit
+
+### 4. Delegate verification
+
+Call the `agent` tool with `subagent_type="improve-test"`.
+
+The test prompt must include:
+
+- isolated worktree path
+- selected task
+- the expected validation scope
+- a requirement to stay read-only
+- a requirement to start the final answer with one of:
+  - `Status: pass`
+  - `Status: fail`
+  - `Status: blocked`
+
+### 5. Repair loop
+
+- If validation returns `Status: fail`, do up to 2 repair rounds.
+- Feed the failure output back to `improve-dev`, then rerun `improve-test`.
+- If validation still fails after 2 repair rounds, remove the worktree and
+  report `Outcome: rolled back`.
+- If validation is `Status: blocked`, remove the worktree and report
+  `Outcome: stopped`.
+
+### 6. Success criteria
+
+Only keep the worktree if all of these are true:
+
+- validation ended with `Status: pass`
+- the worktree has a non-empty diff
+- the change still matches the selected task
+
+If the diff is empty, remove the worktree and report `Outcome: skipped`.
+
+## Final Response
+
+Keep the final response concise and concrete. Include:
+
+- selected task
+- outcome: `success`, `skipped`, `rolled back`, or `stopped`
+- worktree path if kept
+- branch name if kept
+- changed files
+- validation commands and results
+- one short note on remaining risk, if any

--- a/extensions/improve/commands/improve/once.md
+++ b/extensions/improve/commands/improve/once.md
@@ -1,6 +1,7 @@
 ---
 description: Execute one isolated improvement attempt in a temporary worktree.
 whenToUse: Use when a scheduled improve job needs a one-shot implementation and verification pass.
+user-invocable: false
 ---
 
 You are the one-shot executor for `/improve:once`.

--- a/extensions/improve/commands/improve/once.md
+++ b/extensions/improve/commands/improve/once.md
@@ -40,8 +40,9 @@ improvement attempt.
 - Keep the change coherent, worthwhile, and locally verifiable.
 - Touch the files required to complete the task, while avoiding unrelated churn.
 - Do not commit.
-- Never ask the user questions from `/improve:once`. Recurring setup already
-  encoded the user's choices in this prompt.
+- Never use `ask_user_question` or ask the user questions from
+  `/improve:once`. Recurring setup already encoded the user's choices in this
+  prompt, and scheduled executions must run unattended.
 
 ## Workflow
 

--- a/extensions/improve/qwen-extension.json
+++ b/extensions/improve/qwen-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "improve",
+  "version": "0.1.0",
+  "commands": "commands",
+  "agents": "agents"
+}


### PR DESCRIPTION
## Background

The goal of AI-assisted engineering is not only to have an AI help with occasional individual tasks. A more useful direction is to make it possible to run many agents continuously, in parallel, across maintenance work, bug fixes, tests, and small feature improvements.

For that to work in practice, agents need a repeatable workflow that can select scoped tasks, work in isolation, validate results, and keep human involvement focused on review and decision-making. This extension is an example of that kind of workflow for Qwen Code.

## Summary

This pull request adds a standalone `improve` extension example under `extensions/improve`.

The extension demonstrates a prompt-orchestrated repository improvement workflow for Qwen Code. It can run a single improvement immediately, or schedule recurring improvement attempts for the current session when experimental cron tools are enabled.

## What Changed

- Added `extensions/improve/qwen-extension.json` to define the extension package.
- Added `/improve`, the public controller command for one-shot and recurring improvement workflows.
- Added a hidden scheduled-run executor used by recurring jobs.
- Added `improve-dev`, an implementation subagent that works only inside the isolated improvement worktree.
- Added `improve-test`, a read-only validation subagent that checks the result and returns a pass, fail, or blocked verdict.
- Added `extensions/improve/README.md` with usage examples, setup notes, and extension contents.
- Updated the root README to document the new `extensions/` examples area and list the Improve extension as a featured extension.

## Extension Behavior

The example covers these workflow patterns:

- `/improve` with no arguments asks the user which context sources should guide that single run, then selects one meaningful, locally verifiable improvement.
- Directed invocations such as `/improve improve auth flow` keep the run focused on the user's requested area.
- Recurring invocations such as `/improve --every 2h uiux` ask for setup context once before scheduling, then reuse the stored context profile for unattended scheduled runs.
- `/improve list` shows only scheduled improve jobs created by this extension.
- `/improve clear` deletes only those scheduled improve jobs and leaves unrelated cron jobs alone.
- Improvement runs create an isolated git worktree on a real local branch using the `improve/<kind>-<task-slug>-YYYY-MM-DD-<hash>` naming pattern.
- GitHub issue based selection is instructed to skip issues that already have an associated active pull request.
- Validation is delegated to a separate read-only agent before the worktree is kept.

## Validation

- `git diff --check`
- `jq empty extensions/improve/qwen-extension.json`
